### PR TITLE
add evaluation - coherence score calculation

### DIFF
--- a/LDA_news_headlines.ipynb
+++ b/LDA_news_headlines.ipynb
@@ -34,12 +34,14 @@
    "metadata": {},
    "outputs": [
     {
-     "output_type": "execute_result",
      "data": {
-      "text/plain": "10001"
+      "text/plain": [
+       "10001"
+      ]
      },
+     "execution_count": 2,
      "metadata": {},
-     "execution_count": 2
+     "output_type": "execute_result"
     }
    ],
    "source": [
@@ -52,13 +54,72 @@
    "metadata": {},
    "outputs": [
     {
-     "output_type": "execute_result",
      "data": {
-      "text/plain": "                                    headline_text  index\n0  report highlights container terminal potential      0\n1                   mud crab business on the move      1\n2             sporting task force planning begins      2\n3               ama airs hospital reform concerns      3\n4    health service speaks out over patient death      4",
-      "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>headline_text</th>\n      <th>index</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>0</th>\n      <td>report highlights container terminal potential</td>\n      <td>0</td>\n    </tr>\n    <tr>\n      <th>1</th>\n      <td>mud crab business on the move</td>\n      <td>1</td>\n    </tr>\n    <tr>\n      <th>2</th>\n      <td>sporting task force planning begins</td>\n      <td>2</td>\n    </tr>\n    <tr>\n      <th>3</th>\n      <td>ama airs hospital reform concerns</td>\n      <td>3</td>\n    </tr>\n    <tr>\n      <th>4</th>\n      <td>health service speaks out over patient death</td>\n      <td>4</td>\n    </tr>\n  </tbody>\n</table>\n</div>"
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>headline_text</th>\n",
+       "      <th>index</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>report highlights container terminal potential</td>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>mud crab business on the move</td>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>sporting task force planning begins</td>\n",
+       "      <td>2</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>ama airs hospital reform concerns</td>\n",
+       "      <td>3</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>health service speaks out over patient death</td>\n",
+       "      <td>4</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                                    headline_text  index\n",
+       "0  report highlights container terminal potential      0\n",
+       "1                   mud crab business on the move      1\n",
+       "2             sporting task force planning begins      2\n",
+       "3               ama airs hospital reform concerns      3\n",
+       "4    health service speaks out over patient death      4"
+      ]
      },
+     "execution_count": 3,
      "metadata": {},
-     "execution_count": 3
+     "output_type": "execute_result"
     }
    ],
    "source": [
@@ -95,17 +156,23 @@
    },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stderr",
-     "text": "[nltk_data] Downloading package wordnet to\n[nltk_data]     /Users/harrywang/nltk_data...\n[nltk_data]   Package wordnet is already up-to-date!\n"
+     "output_type": "stream",
+     "text": [
+      "[nltk_data] Downloading package wordnet to\n",
+      "[nltk_data]     /Users/rachelzheng/nltk_data...\n",
+      "[nltk_data]   Package wordnet is already up-to-date!\n"
+     ]
     },
     {
-     "output_type": "execute_result",
      "data": {
-      "text/plain": "True"
+      "text/plain": [
+       "True"
+      ]
      },
+     "execution_count": 5,
      "metadata": {},
-     "execution_count": 5
+     "output_type": "execute_result"
     }
    ],
    "source": [
@@ -128,9 +195,11 @@
    },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "go\n"
+     "output_type": "stream",
+     "text": [
+      "go\n"
+     ]
     }
    ],
    "source": [
@@ -150,13 +219,156 @@
    "metadata": {},
    "outputs": [
     {
-     "output_type": "execute_result",
      "data": {
-      "text/plain": "   original word stemmed\n0       caresses  caress\n1          flies     fli\n2           dies     die\n3          mules    mule\n4         denied    deni\n5           died     die\n6         agreed    agre\n7          owned     own\n8        humbled   humbl\n9          sized    size\n10       meeting    meet\n11       stating   state\n12       siezing    siez\n13   itemization    item\n14   sensational  sensat\n15   traditional  tradit\n16     reference   refer\n17     colonizer   colon\n18       plotted    plot",
-      "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>original word</th>\n      <th>stemmed</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>0</th>\n      <td>caresses</td>\n      <td>caress</td>\n    </tr>\n    <tr>\n      <th>1</th>\n      <td>flies</td>\n      <td>fli</td>\n    </tr>\n    <tr>\n      <th>2</th>\n      <td>dies</td>\n      <td>die</td>\n    </tr>\n    <tr>\n      <th>3</th>\n      <td>mules</td>\n      <td>mule</td>\n    </tr>\n    <tr>\n      <th>4</th>\n      <td>denied</td>\n      <td>deni</td>\n    </tr>\n    <tr>\n      <th>5</th>\n      <td>died</td>\n      <td>die</td>\n    </tr>\n    <tr>\n      <th>6</th>\n      <td>agreed</td>\n      <td>agre</td>\n    </tr>\n    <tr>\n      <th>7</th>\n      <td>owned</td>\n      <td>own</td>\n    </tr>\n    <tr>\n      <th>8</th>\n      <td>humbled</td>\n      <td>humbl</td>\n    </tr>\n    <tr>\n      <th>9</th>\n      <td>sized</td>\n      <td>size</td>\n    </tr>\n    <tr>\n      <th>10</th>\n      <td>meeting</td>\n      <td>meet</td>\n    </tr>\n    <tr>\n      <th>11</th>\n      <td>stating</td>\n      <td>state</td>\n    </tr>\n    <tr>\n      <th>12</th>\n      <td>siezing</td>\n      <td>siez</td>\n    </tr>\n    <tr>\n      <th>13</th>\n      <td>itemization</td>\n      <td>item</td>\n    </tr>\n    <tr>\n      <th>14</th>\n      <td>sensational</td>\n      <td>sensat</td>\n    </tr>\n    <tr>\n      <th>15</th>\n      <td>traditional</td>\n      <td>tradit</td>\n    </tr>\n    <tr>\n      <th>16</th>\n      <td>reference</td>\n      <td>refer</td>\n    </tr>\n    <tr>\n      <th>17</th>\n      <td>colonizer</td>\n      <td>colon</td>\n    </tr>\n    <tr>\n      <th>18</th>\n      <td>plotted</td>\n      <td>plot</td>\n    </tr>\n  </tbody>\n</table>\n</div>"
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>original word</th>\n",
+       "      <th>stemmed</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>caresses</td>\n",
+       "      <td>caress</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>flies</td>\n",
+       "      <td>fli</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>dies</td>\n",
+       "      <td>die</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>mules</td>\n",
+       "      <td>mule</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>denied</td>\n",
+       "      <td>deni</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>5</th>\n",
+       "      <td>died</td>\n",
+       "      <td>die</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>6</th>\n",
+       "      <td>agreed</td>\n",
+       "      <td>agre</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>7</th>\n",
+       "      <td>owned</td>\n",
+       "      <td>own</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>8</th>\n",
+       "      <td>humbled</td>\n",
+       "      <td>humbl</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>9</th>\n",
+       "      <td>sized</td>\n",
+       "      <td>size</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>10</th>\n",
+       "      <td>meeting</td>\n",
+       "      <td>meet</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>11</th>\n",
+       "      <td>stating</td>\n",
+       "      <td>state</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>12</th>\n",
+       "      <td>siezing</td>\n",
+       "      <td>siez</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>13</th>\n",
+       "      <td>itemization</td>\n",
+       "      <td>item</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>14</th>\n",
+       "      <td>sensational</td>\n",
+       "      <td>sensat</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>15</th>\n",
+       "      <td>traditional</td>\n",
+       "      <td>tradit</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>16</th>\n",
+       "      <td>reference</td>\n",
+       "      <td>refer</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>17</th>\n",
+       "      <td>colonizer</td>\n",
+       "      <td>colon</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>18</th>\n",
+       "      <td>plotted</td>\n",
+       "      <td>plot</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   original word stemmed\n",
+       "0       caresses  caress\n",
+       "1          flies     fli\n",
+       "2           dies     die\n",
+       "3          mules    mule\n",
+       "4         denied    deni\n",
+       "5           died     die\n",
+       "6         agreed    agre\n",
+       "7          owned     own\n",
+       "8        humbled   humbl\n",
+       "9          sized    size\n",
+       "10       meeting    meet\n",
+       "11       stating   state\n",
+       "12       siezing    siez\n",
+       "13   itemization    item\n",
+       "14   sensational  sensat\n",
+       "15   traditional  tradit\n",
+       "16     reference   refer\n",
+       "17     colonizer   colon\n",
+       "18       plotted    plot"
+      ]
      },
+     "execution_count": 7,
      "metadata": {},
-     "execution_count": 7
+     "output_type": "execute_result"
     }
    ],
    "source": [
@@ -193,9 +405,16 @@
    },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "original document: \n['charity', 'in', 'demand', 'from', 'sacked', 'meatworkers']\n\n\n tokenized and lemmatized document: \n['chariti', 'demand', 'sack', 'meatwork']\n"
+     "output_type": "stream",
+     "text": [
+      "original document: \n",
+      "['charity', 'in', 'demand', 'from', 'sacked', 'meatworkers']\n",
+      "\n",
+      "\n",
+      " tokenized and lemmatized document: \n",
+      "['chariti', 'demand', 'sack', 'meatwork']\n"
+     ]
     }
    ],
    "source": [
@@ -218,9 +437,12 @@
    },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "CPU times: user 1.4 s, sys: 28.6 ms, total: 1.43 s\nWall time: 1.9 s\n"
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 1.56 s, sys: 21 ms, total: 1.59 s\n",
+      "Wall time: 1.64 s\n"
+     ]
     }
    ],
    "source": [
@@ -235,12 +457,24 @@
    "metadata": {},
    "outputs": [
     {
-     "output_type": "execute_result",
      "data": {
-      "text/plain": "0    [report, highlight, contain, termin, potenti]\n1                                     [crab, busi]\n2                 [sport, task, forc, plan, begin]\n3                   [air, hospit, reform, concern]\n4          [health, servic, speak, patient, death]\n5                              [hors, ride, enact]\n6                 [plan, intersect, revamp, begin]\n7                      [stormer, slaughter, shark]\n8               [england, deserv, favourit, oneil]\n9      [firefight, continu, contain, effort, near]\nName: headline_text, dtype: object"
+      "text/plain": [
+       "0    [report, highlight, contain, termin, potenti]\n",
+       "1                                     [crab, busi]\n",
+       "2                 [sport, task, forc, plan, begin]\n",
+       "3                   [air, hospit, reform, concern]\n",
+       "4          [health, servic, speak, patient, death]\n",
+       "5                              [hors, ride, enact]\n",
+       "6                 [plan, intersect, revamp, begin]\n",
+       "7                      [stormer, slaughter, shark]\n",
+       "8               [england, deserv, favourit, oneil]\n",
+       "9      [firefight, continu, contain, effort, near]\n",
+       "Name: headline_text, dtype: object"
+      ]
      },
+     "execution_count": 11,
      "metadata": {},
-     "execution_count": 11
+     "output_type": "execute_result"
     }
    ],
    "source": [
@@ -271,9 +505,21 @@
    },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "0 contain\n1 highlight\n2 potenti\n3 report\n4 termin\n5 busi\n6 crab\n7 begin\n8 forc\n9 plan\n10 sport\n"
+     "output_type": "stream",
+     "text": [
+      "0 contain\n",
+      "1 highlight\n",
+      "2 potenti\n",
+      "3 report\n",
+      "4 termin\n",
+      "5 busi\n",
+      "6 crab\n",
+      "7 begin\n",
+      "8 forc\n",
+      "9 plan\n",
+      "10 sport\n"
+     ]
     }
    ],
    "source": [
@@ -300,12 +546,14 @@
    "metadata": {},
    "outputs": [
     {
-     "output_type": "execute_result",
      "data": {
-      "text/plain": "[(277, 1), (435, 1)]"
+      "text/plain": [
+       "[(277, 1), (435, 1)]"
+      ]
      },
+     "execution_count": 15,
      "metadata": {},
-     "execution_count": 15
+     "output_type": "execute_result"
     }
    ],
    "source": [
@@ -321,9 +569,12 @@
    },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "Word 277 (\"demand\") appears 1 time.\nWord 435 (\"sack\") appears 1 time.\n"
+     "output_type": "stream",
+     "text": [
+      "Word 277 (\"demand\") appears 1 time.\n",
+      "Word 435 (\"sack\") appears 1 time.\n"
+     ]
     }
    ],
    "source": [
@@ -357,13 +608,6 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
    "execution_count": 18,
    "metadata": {},
    "outputs": [],
@@ -379,9 +623,11 @@
    },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "[(0, 0.802436033281265), (1, 0.5967381439893285)]\n"
+     "output_type": "stream",
+     "text": [
+      "[(0, 0.802436033281265), (1, 0.5967381439893285)]\n"
+     ]
     }
    ],
    "source": [
@@ -407,9 +653,12 @@
    },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "CPU times: user 1.4 s, sys: 390 ms, total: 1.79 s\nWall time: 4.78 s\n"
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 2.27 s, sys: 626 ms, total: 2.89 s\n",
+      "Wall time: 4.82 s\n"
+     ]
     }
    ],
    "source": [
@@ -418,16 +667,75 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Evaluate the model by calculating the coherence score. \"Topic Coherence measures score a single topic by measuring the degree of semantic similarity between high scoring words in the topic.\"\n",
+    "\n",
+    "- Detailed introduction: https://towardsdatascience.com/evaluate-topic-model-in-python-latent-dirichlet-allocation-lda-7d57484bb5d0"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 21,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# evaluate the model by calculating the coherence score - we calculate c_v\n",
+    "from gensim.models.coherencemodel import CoherenceModel\n",
+    "cm = CoherenceModel(model=lda_model, texts=processed_docs, dictionary=dictionary, coherence='c_v')\n",
+    "coherence = cm.get_coherence()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Coherence score for our model is: 0.58\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(f\"Coherence score for our model is: {np.round(coherence, 2)}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
    "metadata": {
     "tags": []
    },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "Topic: 0 \nWords: 0.037*\"interview\" + 0.035*\"polic\" + 0.020*\"home\" + 0.015*\"hous\" + 0.014*\"school\" + 0.013*\"brisban\" + 0.012*\"question\" + 0.011*\"plead\" + 0.010*\"mark\" + 0.010*\"sydney\"\nTopic: 1 \nWords: 0.022*\"kill\" + 0.020*\"protest\" + 0.019*\"polic\" + 0.019*\"chang\" + 0.015*\"budget\" + 0.014*\"trump\" + 0.013*\"island\" + 0.013*\"tasmanian\" + 0.013*\"speak\" + 0.011*\"urg\"\nTopic: 2 \nWords: 0.040*\"australia\" + 0.026*\"year\" + 0.019*\"elect\" + 0.016*\"servic\" + 0.015*\"bank\" + 0.014*\"council\" + 0.013*\"miss\" + 0.012*\"vote\" + 0.012*\"plan\" + 0.011*\"high\"\nTopic: 3 \nWords: 0.013*\"plan\" + 0.013*\"govern\" + 0.013*\"court\" + 0.013*\"farmer\" + 0.012*\"public\" + 0.012*\"turnbul\" + 0.012*\"million\" + 0.011*\"campaign\" + 0.011*\"hospit\" + 0.011*\"climat\"\nTopic: 4 \nWords: 0.022*\"open\" + 0.013*\"elect\" + 0.013*\"local\" + 0.012*\"make\" + 0.012*\"trump\" + 0.012*\"adelaid\" + 0.012*\"plan\" + 0.012*\"donald\" + 0.011*\"defend\" + 0.011*\"report\"\nTopic: 5 \nWords: 0.020*\"work\" + 0.017*\"talk\" + 0.016*\"melbourn\" + 0.015*\"help\" + 0.015*\"arrest\" + 0.014*\"drug\" + 0.013*\"australian\" + 0.013*\"win\" + 0.013*\"market\" + 0.012*\"countri\"\nTopic: 6 \nWords: 0.018*\"dead\" + 0.013*\"go\" + 0.013*\"claim\" + 0.013*\"lose\" + 0.011*\"industri\" + 0.010*\"crash\" + 0.010*\"award\" + 0.009*\"region\" + 0.009*\"jail\" + 0.009*\"rule\"\nTopic: 7 \nWords: 0.027*\"say\" + 0.019*\"polic\" + 0.017*\"death\" + 0.015*\"group\" + 0.014*\"australia\" + 0.014*\"charg\" + 0.013*\"court\" + 0.013*\"govern\" + 0.012*\"world\" + 0.011*\"farm\"\nTopic: 8 \nWords: 0.037*\"say\" + 0.026*\"attack\" + 0.016*\"crash\" + 0.015*\"health\" + 0.014*\"state\" + 0.012*\"call\" + 0.012*\"face\" + 0.012*\"woman\" + 0.011*\"report\" + 0.011*\"coast\"\nTopic: 9 \nWords: 0.027*\"charg\" + 0.022*\"australian\" + 0.019*\"warn\" + 0.018*\"face\" + 0.017*\"polic\" + 0.014*\"return\" + 0.013*\"sydney\" + 0.012*\"world\" + 0.012*\"centr\" + 0.012*\"final\"\n"
+     "output_type": "stream",
+     "text": [
+      "Topic: 0 \n",
+      "Words: 0.037*\"interview\" + 0.035*\"polic\" + 0.020*\"home\" + 0.015*\"hous\" + 0.014*\"school\" + 0.013*\"brisban\" + 0.012*\"question\" + 0.011*\"plead\" + 0.010*\"mark\" + 0.010*\"sydney\"\n",
+      "Topic: 1 \n",
+      "Words: 0.022*\"kill\" + 0.020*\"protest\" + 0.019*\"polic\" + 0.019*\"chang\" + 0.015*\"budget\" + 0.014*\"trump\" + 0.013*\"island\" + 0.013*\"tasmanian\" + 0.013*\"speak\" + 0.011*\"urg\"\n",
+      "Topic: 2 \n",
+      "Words: 0.040*\"australia\" + 0.026*\"year\" + 0.019*\"elect\" + 0.016*\"servic\" + 0.015*\"bank\" + 0.014*\"council\" + 0.013*\"miss\" + 0.012*\"vote\" + 0.012*\"plan\" + 0.011*\"high\"\n",
+      "Topic: 3 \n",
+      "Words: 0.013*\"plan\" + 0.013*\"govern\" + 0.013*\"court\" + 0.013*\"farmer\" + 0.012*\"public\" + 0.012*\"turnbul\" + 0.012*\"million\" + 0.011*\"campaign\" + 0.011*\"hospit\" + 0.011*\"climat\"\n",
+      "Topic: 4 \n",
+      "Words: 0.022*\"open\" + 0.013*\"elect\" + 0.013*\"local\" + 0.012*\"make\" + 0.012*\"trump\" + 0.012*\"adelaid\" + 0.012*\"plan\" + 0.012*\"donald\" + 0.011*\"defend\" + 0.011*\"report\"\n",
+      "Topic: 5 \n",
+      "Words: 0.020*\"work\" + 0.017*\"talk\" + 0.016*\"melbourn\" + 0.015*\"help\" + 0.015*\"arrest\" + 0.014*\"drug\" + 0.013*\"australian\" + 0.013*\"win\" + 0.013*\"market\" + 0.012*\"countri\"\n",
+      "Topic: 6 \n",
+      "Words: 0.018*\"dead\" + 0.013*\"go\" + 0.013*\"claim\" + 0.013*\"lose\" + 0.011*\"industri\" + 0.010*\"crash\" + 0.010*\"award\" + 0.009*\"region\" + 0.009*\"jail\" + 0.009*\"rule\"\n",
+      "Topic: 7 \n",
+      "Words: 0.027*\"say\" + 0.019*\"polic\" + 0.017*\"death\" + 0.015*\"group\" + 0.014*\"australia\" + 0.014*\"charg\" + 0.013*\"court\" + 0.013*\"govern\" + 0.012*\"world\" + 0.011*\"farm\"\n",
+      "Topic: 8 \n",
+      "Words: 0.037*\"say\" + 0.026*\"attack\" + 0.016*\"crash\" + 0.015*\"health\" + 0.014*\"state\" + 0.012*\"call\" + 0.012*\"face\" + 0.012*\"woman\" + 0.011*\"report\" + 0.011*\"coast\"\n",
+      "Topic: 9 \n",
+      "Words: 0.027*\"charg\" + 0.022*\"australian\" + 0.019*\"warn\" + 0.018*\"face\" + 0.017*\"polic\" + 0.014*\"return\" + 0.013*\"sydney\" + 0.012*\"world\" + 0.012*\"centr\" + 0.012*\"final\"\n"
+     ]
     }
    ],
    "source": [
@@ -451,15 +759,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 24,
    "metadata": {
     "tags": []
    },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "CPU times: user 1.43 s, sys: 177 ms, total: 1.61 s\nWall time: 3.88 s\n"
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 1.99 s, sys: 210 ms, total: 2.2 s\n",
+      "Wall time: 4.63 s\n"
+     ]
     }
    ],
    "source": [
@@ -469,15 +780,26 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 25,
    "metadata": {
     "tags": []
    },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "Topic: 0 Word: 0.020*\"win\" + 0.017*\"australian\" + 0.017*\"tasmania\" + 0.015*\"test\" + 0.013*\"research\" + 0.013*\"look\" + 0.012*\"cricket\" + 0.011*\"launch\" + 0.010*\"port\" + 0.010*\"food\"\nTopic: 1 Word: 0.026*\"interview\" + 0.020*\"say\" + 0.019*\"woman\" + 0.016*\"charg\" + 0.015*\"final\" + 0.012*\"go\" + 0.012*\"perth\" + 0.009*\"polic\" + 0.009*\"australian\" + 0.008*\"indigen\"\nTopic: 2 Word: 0.019*\"say\" + 0.016*\"market\" + 0.016*\"polic\" + 0.014*\"time\" + 0.013*\"news\" + 0.012*\"brisban\" + 0.011*\"work\" + 0.011*\"melbourn\" + 0.011*\"monday\" + 0.010*\"report\"\nTopic: 3 Word: 0.021*\"elect\" + 0.017*\"miss\" + 0.016*\"plan\" + 0.012*\"talk\" + 0.012*\"centr\" + 0.012*\"leader\" + 0.011*\"aborigin\" + 0.010*\"violenc\" + 0.010*\"white\" + 0.010*\"sydney\"\nTopic: 4 Word: 0.024*\"interview\" + 0.020*\"kill\" + 0.014*\"attack\" + 0.013*\"coast\" + 0.012*\"power\" + 0.011*\"releas\" + 0.011*\"say\" + 0.010*\"peopl\" + 0.010*\"action\" + 0.009*\"step\"\nTopic: 5 Word: 0.017*\"school\" + 0.015*\"stand\" + 0.014*\"hour\" + 0.013*\"trial\" + 0.013*\"fiji\" + 0.012*\"court\" + 0.012*\"open\" + 0.011*\"accus\" + 0.011*\"countri\" + 0.011*\"murder\"\nTopic: 6 Word: 0.019*\"crash\" + 0.016*\"world\" + 0.012*\"adelaid\" + 0.011*\"record\" + 0.011*\"farm\" + 0.010*\"chines\" + 0.010*\"north\" + 0.009*\"queensland\" + 0.009*\"canberra\" + 0.009*\"discuss\"\nTopic: 7 Word: 0.018*\"govern\" + 0.016*\"want\" + 0.012*\"group\" + 0.012*\"child\" + 0.010*\"fund\" + 0.010*\"abus\" + 0.010*\"train\" + 0.010*\"sentenc\" + 0.010*\"year\" + 0.009*\"call\"\nTopic: 8 Word: 0.025*\"australia\" + 0.016*\"warn\" + 0.014*\"farmer\" + 0.012*\"court\" + 0.012*\"announc\" + 0.012*\"law\" + 0.011*\"open\" + 0.010*\"land\" + 0.010*\"lead\" + 0.010*\"tasmanian\"\nTopic: 9 Word: 0.020*\"trump\" + 0.018*\"death\" + 0.011*\"make\" + 0.011*\"hospit\" + 0.011*\"australian\" + 0.010*\"donald\" + 0.010*\"perth\" + 0.010*\"tuesday\" + 0.009*\"water\" + 0.009*\"royal\"\n"
+     "output_type": "stream",
+     "text": [
+      "Topic: 0 Word: 0.020*\"win\" + 0.017*\"australian\" + 0.017*\"tasmania\" + 0.015*\"test\" + 0.013*\"research\" + 0.013*\"look\" + 0.012*\"cricket\" + 0.011*\"launch\" + 0.010*\"port\" + 0.010*\"food\"\n",
+      "Topic: 1 Word: 0.026*\"interview\" + 0.020*\"say\" + 0.019*\"woman\" + 0.016*\"charg\" + 0.015*\"final\" + 0.012*\"go\" + 0.012*\"perth\" + 0.009*\"polic\" + 0.009*\"australian\" + 0.008*\"indigen\"\n",
+      "Topic: 2 Word: 0.019*\"say\" + 0.016*\"market\" + 0.016*\"polic\" + 0.014*\"time\" + 0.013*\"news\" + 0.012*\"brisban\" + 0.011*\"work\" + 0.011*\"melbourn\" + 0.011*\"monday\" + 0.010*\"report\"\n",
+      "Topic: 3 Word: 0.021*\"elect\" + 0.017*\"miss\" + 0.016*\"plan\" + 0.012*\"talk\" + 0.012*\"centr\" + 0.012*\"leader\" + 0.011*\"aborigin\" + 0.010*\"violenc\" + 0.010*\"white\" + 0.010*\"sydney\"\n",
+      "Topic: 4 Word: 0.024*\"interview\" + 0.020*\"kill\" + 0.014*\"attack\" + 0.013*\"coast\" + 0.012*\"power\" + 0.011*\"releas\" + 0.011*\"say\" + 0.010*\"peopl\" + 0.010*\"action\" + 0.009*\"step\"\n",
+      "Topic: 5 Word: 0.017*\"school\" + 0.015*\"stand\" + 0.014*\"hour\" + 0.013*\"trial\" + 0.013*\"fiji\" + 0.012*\"court\" + 0.012*\"open\" + 0.011*\"accus\" + 0.011*\"countri\" + 0.011*\"murder\"\n",
+      "Topic: 6 Word: 0.019*\"crash\" + 0.016*\"world\" + 0.012*\"adelaid\" + 0.011*\"record\" + 0.011*\"farm\" + 0.010*\"chines\" + 0.010*\"north\" + 0.009*\"queensland\" + 0.009*\"canberra\" + 0.009*\"discuss\"\n",
+      "Topic: 7 Word: 0.018*\"govern\" + 0.016*\"want\" + 0.012*\"group\" + 0.012*\"child\" + 0.010*\"fund\" + 0.010*\"abus\" + 0.010*\"train\" + 0.010*\"sentenc\" + 0.010*\"year\" + 0.009*\"call\"\n",
+      "Topic: 8 Word: 0.025*\"australia\" + 0.016*\"warn\" + 0.014*\"farmer\" + 0.012*\"court\" + 0.012*\"announc\" + 0.012*\"law\" + 0.011*\"open\" + 0.010*\"land\" + 0.010*\"lead\" + 0.010*\"tasmanian\"\n",
+      "Topic: 9 Word: 0.020*\"trump\" + 0.018*\"death\" + 0.011*\"make\" + 0.011*\"hospit\" + 0.011*\"australian\" + 0.010*\"donald\" + 0.010*\"perth\" + 0.010*\"tuesday\" + 0.009*\"water\" + 0.009*\"royal\"\n"
+     ]
     }
    ],
    "source": [
@@ -501,16 +823,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 26,
    "metadata": {},
    "outputs": [
     {
-     "output_type": "execute_result",
      "data": {
-      "text/plain": "['chariti', 'demand', 'sack', 'meatwork']"
+      "text/plain": [
+       "['chariti', 'demand', 'sack', 'meatwork']"
+      ]
      },
+     "execution_count": 26,
      "metadata": {},
-     "execution_count": 24
+     "output_type": "execute_result"
     }
    ],
    "source": [
@@ -519,15 +843,46 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 27,
    "metadata": {
     "tags": []
    },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "\nScore: 0.6999604105949402\t \nTopic: 0.018*\"dead\" + 0.013*\"go\" + 0.013*\"claim\" + 0.013*\"lose\" + 0.011*\"industri\" + 0.010*\"crash\" + 0.010*\"award\" + 0.009*\"region\" + 0.009*\"jail\" + 0.009*\"rule\"\n\nScore: 0.033347394317388535\t \nTopic: 0.013*\"plan\" + 0.013*\"govern\" + 0.013*\"court\" + 0.013*\"farmer\" + 0.012*\"public\" + 0.012*\"turnbul\" + 0.012*\"million\" + 0.011*\"campaign\" + 0.011*\"hospit\" + 0.011*\"climat\"\n\nScore: 0.03334241360425949\t \nTopic: 0.040*\"australia\" + 0.026*\"year\" + 0.019*\"elect\" + 0.016*\"servic\" + 0.015*\"bank\" + 0.014*\"council\" + 0.013*\"miss\" + 0.012*\"vote\" + 0.012*\"plan\" + 0.011*\"high\"\n\nScore: 0.033337824046611786\t \nTopic: 0.037*\"say\" + 0.026*\"attack\" + 0.016*\"crash\" + 0.015*\"health\" + 0.014*\"state\" + 0.012*\"call\" + 0.012*\"face\" + 0.012*\"woman\" + 0.011*\"report\" + 0.011*\"coast\"\n\nScore: 0.03333580866456032\t \nTopic: 0.022*\"open\" + 0.013*\"elect\" + 0.013*\"local\" + 0.012*\"make\" + 0.012*\"trump\" + 0.012*\"adelaid\" + 0.012*\"plan\" + 0.012*\"donald\" + 0.011*\"defend\" + 0.011*\"report\"\n\nScore: 0.033335328102111816\t \nTopic: 0.027*\"charg\" + 0.022*\"australian\" + 0.019*\"warn\" + 0.018*\"face\" + 0.017*\"polic\" + 0.014*\"return\" + 0.013*\"sydney\" + 0.012*\"world\" + 0.012*\"centr\" + 0.012*\"final\"\n\nScore: 0.03333524614572525\t \nTopic: 0.027*\"say\" + 0.019*\"polic\" + 0.017*\"death\" + 0.015*\"group\" + 0.014*\"australia\" + 0.014*\"charg\" + 0.013*\"court\" + 0.013*\"govern\" + 0.012*\"world\" + 0.011*\"farm\"\n\nScore: 0.033335208892822266\t \nTopic: 0.020*\"work\" + 0.017*\"talk\" + 0.016*\"melbourn\" + 0.015*\"help\" + 0.015*\"arrest\" + 0.014*\"drug\" + 0.013*\"australian\" + 0.013*\"win\" + 0.013*\"market\" + 0.012*\"countri\"\n\nScore: 0.03333519399166107\t \nTopic: 0.037*\"interview\" + 0.035*\"polic\" + 0.020*\"home\" + 0.015*\"hous\" + 0.014*\"school\" + 0.013*\"brisban\" + 0.012*\"question\" + 0.011*\"plead\" + 0.010*\"mark\" + 0.010*\"sydney\"\n\nScore: 0.03333517909049988\t \nTopic: 0.022*\"kill\" + 0.020*\"protest\" + 0.019*\"polic\" + 0.019*\"chang\" + 0.015*\"budget\" + 0.014*\"trump\" + 0.013*\"island\" + 0.013*\"tasmanian\" + 0.013*\"speak\" + 0.011*\"urg\"\n"
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Score: 0.6999604105949402\t \n",
+      "Topic: 0.018*\"dead\" + 0.013*\"go\" + 0.013*\"claim\" + 0.013*\"lose\" + 0.011*\"industri\" + 0.010*\"crash\" + 0.010*\"award\" + 0.009*\"region\" + 0.009*\"jail\" + 0.009*\"rule\"\n",
+      "\n",
+      "Score: 0.033347394317388535\t \n",
+      "Topic: 0.013*\"plan\" + 0.013*\"govern\" + 0.013*\"court\" + 0.013*\"farmer\" + 0.012*\"public\" + 0.012*\"turnbul\" + 0.012*\"million\" + 0.011*\"campaign\" + 0.011*\"hospit\" + 0.011*\"climat\"\n",
+      "\n",
+      "Score: 0.03334241360425949\t \n",
+      "Topic: 0.040*\"australia\" + 0.026*\"year\" + 0.019*\"elect\" + 0.016*\"servic\" + 0.015*\"bank\" + 0.014*\"council\" + 0.013*\"miss\" + 0.012*\"vote\" + 0.012*\"plan\" + 0.011*\"high\"\n",
+      "\n",
+      "Score: 0.033337824046611786\t \n",
+      "Topic: 0.037*\"say\" + 0.026*\"attack\" + 0.016*\"crash\" + 0.015*\"health\" + 0.014*\"state\" + 0.012*\"call\" + 0.012*\"face\" + 0.012*\"woman\" + 0.011*\"report\" + 0.011*\"coast\"\n",
+      "\n",
+      "Score: 0.03333580866456032\t \n",
+      "Topic: 0.022*\"open\" + 0.013*\"elect\" + 0.013*\"local\" + 0.012*\"make\" + 0.012*\"trump\" + 0.012*\"adelaid\" + 0.012*\"plan\" + 0.012*\"donald\" + 0.011*\"defend\" + 0.011*\"report\"\n",
+      "\n",
+      "Score: 0.033335328102111816\t \n",
+      "Topic: 0.027*\"charg\" + 0.022*\"australian\" + 0.019*\"warn\" + 0.018*\"face\" + 0.017*\"polic\" + 0.014*\"return\" + 0.013*\"sydney\" + 0.012*\"world\" + 0.012*\"centr\" + 0.012*\"final\"\n",
+      "\n",
+      "Score: 0.03333524614572525\t \n",
+      "Topic: 0.027*\"say\" + 0.019*\"polic\" + 0.017*\"death\" + 0.015*\"group\" + 0.014*\"australia\" + 0.014*\"charg\" + 0.013*\"court\" + 0.013*\"govern\" + 0.012*\"world\" + 0.011*\"farm\"\n",
+      "\n",
+      "Score: 0.033335208892822266\t \n",
+      "Topic: 0.020*\"work\" + 0.017*\"talk\" + 0.016*\"melbourn\" + 0.015*\"help\" + 0.015*\"arrest\" + 0.014*\"drug\" + 0.013*\"australian\" + 0.013*\"win\" + 0.013*\"market\" + 0.012*\"countri\"\n",
+      "\n",
+      "Score: 0.03333519399166107\t \n",
+      "Topic: 0.037*\"interview\" + 0.035*\"polic\" + 0.020*\"home\" + 0.015*\"hous\" + 0.014*\"school\" + 0.013*\"brisban\" + 0.012*\"question\" + 0.011*\"plead\" + 0.010*\"mark\" + 0.010*\"sydney\"\n",
+      "\n",
+      "Score: 0.03333517909049988\t \n",
+      "Topic: 0.022*\"kill\" + 0.020*\"protest\" + 0.019*\"polic\" + 0.019*\"chang\" + 0.015*\"budget\" + 0.014*\"trump\" + 0.013*\"island\" + 0.013*\"tasmanian\" + 0.013*\"speak\" + 0.011*\"urg\"\n"
+     ]
     }
    ],
    "source": [
@@ -551,15 +906,46 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 28,
    "metadata": {
     "tags": []
    },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "\nScore: 0.6999433040618896\t \nTopic: 0.024*\"interview\" + 0.020*\"kill\" + 0.014*\"attack\" + 0.013*\"coast\" + 0.012*\"power\" + 0.011*\"releas\" + 0.011*\"say\" + 0.010*\"peopl\" + 0.010*\"action\" + 0.009*\"step\"\n\nScore: 0.0333525687456131\t \nTopic: 0.018*\"govern\" + 0.016*\"want\" + 0.012*\"group\" + 0.012*\"child\" + 0.010*\"fund\" + 0.010*\"abus\" + 0.010*\"train\" + 0.010*\"sentenc\" + 0.010*\"year\" + 0.009*\"call\"\n\nScore: 0.03334299474954605\t \nTopic: 0.026*\"interview\" + 0.020*\"say\" + 0.019*\"woman\" + 0.016*\"charg\" + 0.015*\"final\" + 0.012*\"go\" + 0.012*\"perth\" + 0.009*\"polic\" + 0.009*\"australian\" + 0.008*\"indigen\"\n\nScore: 0.033339973539114\t \nTopic: 0.020*\"trump\" + 0.018*\"death\" + 0.011*\"make\" + 0.011*\"hospit\" + 0.011*\"australian\" + 0.010*\"donald\" + 0.010*\"perth\" + 0.010*\"tuesday\" + 0.009*\"water\" + 0.009*\"royal\"\n\nScore: 0.033338554203510284\t \nTopic: 0.019*\"crash\" + 0.016*\"world\" + 0.012*\"adelaid\" + 0.011*\"record\" + 0.011*\"farm\" + 0.010*\"chines\" + 0.010*\"north\" + 0.009*\"queensland\" + 0.009*\"canberra\" + 0.009*\"discuss\"\n\nScore: 0.033337488770484924\t \nTopic: 0.017*\"school\" + 0.015*\"stand\" + 0.014*\"hour\" + 0.013*\"trial\" + 0.013*\"fiji\" + 0.012*\"court\" + 0.012*\"open\" + 0.011*\"accus\" + 0.011*\"countri\" + 0.011*\"murder\"\n\nScore: 0.03333703428506851\t \nTopic: 0.019*\"say\" + 0.016*\"market\" + 0.016*\"polic\" + 0.014*\"time\" + 0.013*\"news\" + 0.012*\"brisban\" + 0.011*\"work\" + 0.011*\"melbourn\" + 0.011*\"monday\" + 0.010*\"report\"\n\nScore: 0.0333360955119133\t \nTopic: 0.020*\"win\" + 0.017*\"australian\" + 0.017*\"tasmania\" + 0.015*\"test\" + 0.013*\"research\" + 0.013*\"look\" + 0.012*\"cricket\" + 0.011*\"launch\" + 0.010*\"port\" + 0.010*\"food\"\n\nScore: 0.033336006104946136\t \nTopic: 0.025*\"australia\" + 0.016*\"warn\" + 0.014*\"farmer\" + 0.012*\"court\" + 0.012*\"announc\" + 0.012*\"law\" + 0.011*\"open\" + 0.010*\"land\" + 0.010*\"lead\" + 0.010*\"tasmanian\"\n\nScore: 0.03333596512675285\t \nTopic: 0.021*\"elect\" + 0.017*\"miss\" + 0.016*\"plan\" + 0.012*\"talk\" + 0.012*\"centr\" + 0.012*\"leader\" + 0.011*\"aborigin\" + 0.010*\"violenc\" + 0.010*\"white\" + 0.010*\"sydney\"\n"
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Score: 0.6999433040618896\t \n",
+      "Topic: 0.024*\"interview\" + 0.020*\"kill\" + 0.014*\"attack\" + 0.013*\"coast\" + 0.012*\"power\" + 0.011*\"releas\" + 0.011*\"say\" + 0.010*\"peopl\" + 0.010*\"action\" + 0.009*\"step\"\n",
+      "\n",
+      "Score: 0.0333525724709034\t \n",
+      "Topic: 0.018*\"govern\" + 0.016*\"want\" + 0.012*\"group\" + 0.012*\"child\" + 0.010*\"fund\" + 0.010*\"abus\" + 0.010*\"train\" + 0.010*\"sentenc\" + 0.010*\"year\" + 0.009*\"call\"\n",
+      "\n",
+      "Score: 0.03334299474954605\t \n",
+      "Topic: 0.026*\"interview\" + 0.020*\"say\" + 0.019*\"woman\" + 0.016*\"charg\" + 0.015*\"final\" + 0.012*\"go\" + 0.012*\"perth\" + 0.009*\"polic\" + 0.009*\"australian\" + 0.008*\"indigen\"\n",
+      "\n",
+      "Score: 0.0333399772644043\t \n",
+      "Topic: 0.020*\"trump\" + 0.018*\"death\" + 0.011*\"make\" + 0.011*\"hospit\" + 0.011*\"australian\" + 0.010*\"donald\" + 0.010*\"perth\" + 0.010*\"tuesday\" + 0.009*\"water\" + 0.009*\"royal\"\n",
+      "\n",
+      "Score: 0.033338554203510284\t \n",
+      "Topic: 0.019*\"crash\" + 0.016*\"world\" + 0.012*\"adelaid\" + 0.011*\"record\" + 0.011*\"farm\" + 0.010*\"chines\" + 0.010*\"north\" + 0.009*\"queensland\" + 0.009*\"canberra\" + 0.009*\"discuss\"\n",
+      "\n",
+      "Score: 0.033337488770484924\t \n",
+      "Topic: 0.017*\"school\" + 0.015*\"stand\" + 0.014*\"hour\" + 0.013*\"trial\" + 0.013*\"fiji\" + 0.012*\"court\" + 0.012*\"open\" + 0.011*\"accus\" + 0.011*\"countri\" + 0.011*\"murder\"\n",
+      "\n",
+      "Score: 0.03333703428506851\t \n",
+      "Topic: 0.019*\"say\" + 0.016*\"market\" + 0.016*\"polic\" + 0.014*\"time\" + 0.013*\"news\" + 0.012*\"brisban\" + 0.011*\"work\" + 0.011*\"melbourn\" + 0.011*\"monday\" + 0.010*\"report\"\n",
+      "\n",
+      "Score: 0.0333360955119133\t \n",
+      "Topic: 0.020*\"win\" + 0.017*\"australian\" + 0.017*\"tasmania\" + 0.015*\"test\" + 0.013*\"research\" + 0.013*\"look\" + 0.012*\"cricket\" + 0.011*\"launch\" + 0.010*\"port\" + 0.010*\"food\"\n",
+      "\n",
+      "Score: 0.033336006104946136\t \n",
+      "Topic: 0.025*\"australia\" + 0.016*\"warn\" + 0.014*\"farmer\" + 0.012*\"court\" + 0.012*\"announc\" + 0.012*\"law\" + 0.011*\"open\" + 0.010*\"land\" + 0.010*\"lead\" + 0.010*\"tasmanian\"\n",
+      "\n",
+      "Score: 0.03333596885204315\t \n",
+      "Topic: 0.021*\"elect\" + 0.017*\"miss\" + 0.016*\"plan\" + 0.012*\"talk\" + 0.012*\"centr\" + 0.012*\"leader\" + 0.011*\"aborigin\" + 0.010*\"violenc\" + 0.010*\"white\" + 0.010*\"sydney\"\n"
+     ]
     }
    ],
    "source": [
@@ -583,15 +969,26 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 29,
    "metadata": {
     "tags": []
    },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "Score: 0.6999323964118958\t Topic: 0.020*\"work\" + 0.017*\"talk\" + 0.016*\"melbourn\" + 0.015*\"help\" + 0.015*\"arrest\"\nScore: 0.03335041552782059\t Topic: 0.013*\"plan\" + 0.013*\"govern\" + 0.013*\"court\" + 0.013*\"farmer\" + 0.012*\"public\"\nScore: 0.03334531560540199\t Topic: 0.037*\"say\" + 0.026*\"attack\" + 0.016*\"crash\" + 0.015*\"health\" + 0.014*\"state\"\nScore: 0.0333448089659214\t Topic: 0.040*\"australia\" + 0.026*\"year\" + 0.019*\"elect\" + 0.016*\"servic\" + 0.015*\"bank\"\nScore: 0.033340469002723694\t Topic: 0.022*\"open\" + 0.013*\"elect\" + 0.013*\"local\" + 0.012*\"make\" + 0.012*\"trump\"\nScore: 0.03334016725420952\t Topic: 0.027*\"charg\" + 0.022*\"australian\" + 0.019*\"warn\" + 0.018*\"face\" + 0.017*\"polic\"\nScore: 0.0333387665450573\t Topic: 0.018*\"dead\" + 0.013*\"go\" + 0.013*\"claim\" + 0.013*\"lose\" + 0.011*\"industri\"\nScore: 0.03333800658583641\t Topic: 0.027*\"say\" + 0.019*\"polic\" + 0.017*\"death\" + 0.015*\"group\" + 0.014*\"australia\"\nScore: 0.03333493694663048\t Topic: 0.037*\"interview\" + 0.035*\"polic\" + 0.020*\"home\" + 0.015*\"hous\" + 0.014*\"school\"\nScore: 0.03333476185798645\t Topic: 0.022*\"kill\" + 0.020*\"protest\" + 0.019*\"polic\" + 0.019*\"chang\" + 0.015*\"budget\"\n"
+     "output_type": "stream",
+     "text": [
+      "Score: 0.6999323964118958\t Topic: 0.020*\"work\" + 0.017*\"talk\" + 0.016*\"melbourn\" + 0.015*\"help\" + 0.015*\"arrest\"\n",
+      "Score: 0.03335041552782059\t Topic: 0.013*\"plan\" + 0.013*\"govern\" + 0.013*\"court\" + 0.013*\"farmer\" + 0.012*\"public\"\n",
+      "Score: 0.03334531560540199\t Topic: 0.037*\"say\" + 0.026*\"attack\" + 0.016*\"crash\" + 0.015*\"health\" + 0.014*\"state\"\n",
+      "Score: 0.0333448089659214\t Topic: 0.040*\"australia\" + 0.026*\"year\" + 0.019*\"elect\" + 0.016*\"servic\" + 0.015*\"bank\"\n",
+      "Score: 0.033340469002723694\t Topic: 0.022*\"open\" + 0.013*\"elect\" + 0.013*\"local\" + 0.012*\"make\" + 0.012*\"trump\"\n",
+      "Score: 0.03334016725420952\t Topic: 0.027*\"charg\" + 0.022*\"australian\" + 0.019*\"warn\" + 0.018*\"face\" + 0.017*\"polic\"\n",
+      "Score: 0.0333387665450573\t Topic: 0.018*\"dead\" + 0.013*\"go\" + 0.013*\"claim\" + 0.013*\"lose\" + 0.011*\"industri\"\n",
+      "Score: 0.03333800658583641\t Topic: 0.027*\"say\" + 0.019*\"polic\" + 0.017*\"death\" + 0.015*\"group\" + 0.014*\"australia\"\n",
+      "Score: 0.03333493694663048\t Topic: 0.037*\"interview\" + 0.035*\"polic\" + 0.020*\"home\" + 0.015*\"hous\" + 0.014*\"school\"\n",
+      "Score: 0.03333476185798645\t Topic: 0.022*\"kill\" + 0.020*\"protest\" + 0.019*\"polic\" + 0.019*\"chang\" + 0.015*\"budget\"\n"
+     ]
     }
    ],
    "source": [
@@ -604,29 +1001,38 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 30,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 3 µs, sys: 0 ns, total: 3 µs\n",
+      "Wall time: 8.11 µs\n"
+     ]
+    }
+   ],
    "source": [
     "%%time\n",
     "# random choose 10,000 about 1/100 from the whole dataset\n",
     "# no need to run this\n",
-    "import random\n",
+    "# import random\n",
     "\n",
-    "n = 1186018 # 1 million total \n",
-    "s = 10000 # random 10k\n",
-    "skip = sorted(random.sample(range(n), n-s))\n",
-    "data_small = pd.read_csv('data/abcnews-date-text.csv', skiprows=skip, error_bad_lines=False, names=['index', 'headline_text'])\n",
-    "data_small.drop('index', axis=1, inplace=True)\n",
-    "data_small.to_csv('data/abcnews-small.csv')"
+    "# n = 1186018 # 1 million total \n",
+    "# s = 10000 # random 10k\n",
+    "# skip = sorted(random.sample(range(n), n-s))\n",
+    "# data_small = pd.read_csv('data/abcnews-date-text.csv', skiprows=skip, error_bad_lines=False, names=['index', 'headline_text'])\n",
+    "# data_small.drop('index', axis=1, inplace=True)\n",
+    "# data_small.to_csv('data/abcnews-small.csv')"
    ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3.7.6 64-bit ('venv': venv)",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "python_defaultSpec_1598387176193"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -638,7 +1044,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.6-final"
+   "version": "3.7.7"
   }
  },
  "nbformat": 4,

--- a/LDA_podcast.ipynb
+++ b/LDA_podcast.ipynb
@@ -9,7 +9,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 131,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -21,16 +21,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 132,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [
     {
-     "output_type": "execute_result",
      "data": {
-      "text/plain": "142"
+      "text/plain": [
+       "142"
+      ]
      },
+     "execution_count": 2,
      "metadata": {},
-     "execution_count": 132
+     "output_type": "execute_result"
     }
    ],
    "source": [
@@ -39,17 +41,70 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 133,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [
     {
-     "output_type": "execute_result",
      "data": {
-      "text/plain": "                                            headline\n0                                        Let's face.\n1               It podcasting is a booming business.\n2  I have information that I want the world to he...\n3                                    Well good news.\n4              I found the answer anchor anchor dot.",
-      "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>headline</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>0</th>\n      <td>Let's face.</td>\n    </tr>\n    <tr>\n      <th>1</th>\n      <td>It podcasting is a booming business.</td>\n    </tr>\n    <tr>\n      <th>2</th>\n      <td>I have information that I want the world to he...</td>\n    </tr>\n    <tr>\n      <th>3</th>\n      <td>Well good news.</td>\n    </tr>\n    <tr>\n      <th>4</th>\n      <td>I found the answer anchor anchor dot.</td>\n    </tr>\n  </tbody>\n</table>\n</div>"
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>headline</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>Let's face.</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>It podcasting is a booming business.</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>I have information that I want the world to he...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>Well good news.</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>I found the answer anchor anchor dot.</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                                            headline\n",
+       "0                                        Let's face.\n",
+       "1               It podcasting is a booming business.\n",
+       "2  I have information that I want the world to he...\n",
+       "3                                    Well good news.\n",
+       "4              I found the answer anchor anchor dot."
+      ]
      },
+     "execution_count": 3,
      "metadata": {},
-     "execution_count": 133
+     "output_type": "execute_result"
     }
    ],
    "source": [
@@ -65,7 +120,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 134,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -80,23 +135,29 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 135,
+   "execution_count": 5,
    "metadata": {
     "tags": []
    },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stderr",
-     "text": "[nltk_data] Downloading package wordnet to\n[nltk_data]     /Users/harrywang/nltk_data...\n[nltk_data]   Package wordnet is already up-to-date!\n"
+     "output_type": "stream",
+     "text": [
+      "[nltk_data] Downloading package wordnet to\n",
+      "[nltk_data]     /Users/rachelzheng/nltk_data...\n",
+      "[nltk_data]   Package wordnet is already up-to-date!\n"
+     ]
     },
     {
-     "output_type": "execute_result",
      "data": {
-      "text/plain": "True"
+      "text/plain": [
+       "True"
+      ]
      },
+     "execution_count": 5,
      "metadata": {},
-     "execution_count": 135
+     "output_type": "execute_result"
     }
    ],
    "source": [
@@ -106,7 +167,174 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 136,
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>original word</th>\n",
+       "      <th>stemmed</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>caresses</td>\n",
+       "      <td>caress</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>flies</td>\n",
+       "      <td>fli</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>dies</td>\n",
+       "      <td>die</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>mules</td>\n",
+       "      <td>mule</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>denied</td>\n",
+       "      <td>deni</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>5</th>\n",
+       "      <td>died</td>\n",
+       "      <td>die</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>6</th>\n",
+       "      <td>agreed</td>\n",
+       "      <td>agre</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>7</th>\n",
+       "      <td>owned</td>\n",
+       "      <td>own</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>8</th>\n",
+       "      <td>humbled</td>\n",
+       "      <td>humbl</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>9</th>\n",
+       "      <td>sized</td>\n",
+       "      <td>size</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>10</th>\n",
+       "      <td>meeting</td>\n",
+       "      <td>meet</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>11</th>\n",
+       "      <td>stating</td>\n",
+       "      <td>state</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>12</th>\n",
+       "      <td>siezing</td>\n",
+       "      <td>siez</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>13</th>\n",
+       "      <td>itemization</td>\n",
+       "      <td>item</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>14</th>\n",
+       "      <td>sensational</td>\n",
+       "      <td>sensat</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>15</th>\n",
+       "      <td>traditional</td>\n",
+       "      <td>tradit</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>16</th>\n",
+       "      <td>reference</td>\n",
+       "      <td>refer</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>17</th>\n",
+       "      <td>colonizer</td>\n",
+       "      <td>colon</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>18</th>\n",
+       "      <td>plotted</td>\n",
+       "      <td>plot</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   original word stemmed\n",
+       "0       caresses  caress\n",
+       "1          flies     fli\n",
+       "2           dies     die\n",
+       "3          mules    mule\n",
+       "4         denied    deni\n",
+       "5           died     die\n",
+       "6         agreed    agre\n",
+       "7          owned     own\n",
+       "8        humbled   humbl\n",
+       "9          sized    size\n",
+       "10       meeting    meet\n",
+       "11       stating   state\n",
+       "12       siezing    siez\n",
+       "13   itemization    item\n",
+       "14   sensational  sensat\n",
+       "15   traditional  tradit\n",
+       "16     reference   refer\n",
+       "17     colonizer   colon\n",
+       "18       plotted    plot"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "stemmer = SnowballStemmer('english')\n",
+    "original_words = ['caresses', 'flies', 'dies', 'mules', 'denied','died', 'agreed', 'owned', \n",
+    "           'humbled', 'sized','meeting', 'stating', 'siezing', 'itemization','sensational', \n",
+    "           'traditional', 'reference', 'colonizer','plotted']\n",
+    "singles = [stemmer.stem(plural) for plural in original_words]\n",
+    "pd.DataFrame(data = {'original word': original_words, 'stemmed': singles})"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -123,15 +351,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 137,
+   "execution_count": 8,
    "metadata": {
     "tags": []
    },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "CPU times: user 46.5 ms, sys: 2.26 ms, total: 48.7 ms\nWall time: 70.5 ms\n"
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 2.01 s, sys: 88.5 ms, total: 2.1 s\n",
+      "Wall time: 2.18 s\n"
+     ]
     }
    ],
    "source": [
@@ -141,16 +372,28 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 138,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [
     {
-     "output_type": "execute_result",
      "data": {
-      "text/plain": "0                                               [face]\n1                                [podcast, boom, busi]\n2    [inform, want, world, hear, want, outrag, fee,...\n3                                         [good, news]\n4                             [answer, anchor, anchor]\n5    [anchor, creat, content, distribut, free, worl...\n6            [record, add, pay, play, listen, audienc]\n7    [record, host, guest, music, bumper, track, im...\n8    [want, creat, podcast, budget, expens, studio,...\n9    [work, match, respons, listen, audienc, pay, p...\nName: headline, dtype: object"
+      "text/plain": [
+       "0                                               [face]\n",
+       "1                                [podcast, boom, busi]\n",
+       "2    [inform, want, world, hear, want, outrag, fee,...\n",
+       "3                                         [good, news]\n",
+       "4                             [answer, anchor, anchor]\n",
+       "5    [anchor, creat, content, distribut, free, worl...\n",
+       "6            [record, add, pay, play, listen, audienc]\n",
+       "7    [record, host, guest, music, bumper, track, im...\n",
+       "8    [want, creat, podcast, budget, expens, studio,...\n",
+       "9    [work, match, respons, listen, audienc, pay, p...\n",
+       "Name: headline, dtype: object"
+      ]
      },
+     "execution_count": 9,
      "metadata": {},
-     "execution_count": 138
+     "output_type": "execute_result"
     }
    ],
    "source": [
@@ -166,7 +409,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 139,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -175,15 +418,27 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 140,
+   "execution_count": 11,
    "metadata": {
     "tags": []
    },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "0 face\n1 boom\n2 busi\n3 podcast\n4 charg\n5 distributor\n6 fee\n7 hear\n8 inform\n9 outrag\n10 want\n"
+     "output_type": "stream",
+     "text": [
+      "0 face\n",
+      "1 boom\n",
+      "2 busi\n",
+      "3 podcast\n",
+      "4 charg\n",
+      "5 distributor\n",
+      "6 fee\n",
+      "7 hear\n",
+      "8 inform\n",
+      "9 outrag\n",
+      "10 want\n"
+     ]
     }
    ],
    "source": [
@@ -197,7 +452,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 141,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -212,7 +467,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 142,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -221,15 +476,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 143,
+   "execution_count": 14,
    "metadata": {
     "tags": []
    },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "Word 4 (\"charg\") appears 1 time.\nWord 5 (\"distributor\") appears 1 time.\nWord 6 (\"fee\") appears 1 time.\nWord 7 (\"hear\") appears 1 time.\nWord 8 (\"inform\") appears 1 time.\nWord 9 (\"outrag\") appears 1 time.\nWord 10 (\"want\") appears 2 time.\nWord 11 (\"world\") appears 1 time.\n"
+     "output_type": "stream",
+     "text": [
+      "Word 4 (\"charg\") appears 1 time.\n",
+      "Word 5 (\"distributor\") appears 1 time.\n",
+      "Word 6 (\"fee\") appears 1 time.\n",
+      "Word 7 (\"hear\") appears 1 time.\n",
+      "Word 8 (\"inform\") appears 1 time.\n",
+      "Word 9 (\"outrag\") appears 1 time.\n",
+      "Word 10 (\"want\") appears 2 time.\n",
+      "Word 11 (\"world\") appears 1 time.\n"
+     ]
     }
    ],
    "source": [
@@ -250,7 +514,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 144,
+   "execution_count": 15,
    "metadata": {
     "tags": []
    },
@@ -263,7 +527,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 145,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -272,15 +536,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 146,
+   "execution_count": 17,
    "metadata": {
     "tags": []
    },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "[(0, 1.0)]\n"
+     "output_type": "stream",
+     "text": [
+      "[(0, 1.0)]\n"
+     ]
     }
    ],
    "source": [
@@ -300,15 +566,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 147,
+   "execution_count": 18,
    "metadata": {
     "tags": []
    },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "CPU times: user 196 ms, sys: 39.6 ms, total: 235 ms\nWall time: 863 ms\n"
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 207 ms, sys: 46.9 ms, total: 254 ms\n",
+      "Wall time: 332 ms\n"
+     ]
     }
    ],
    "source": [
@@ -317,16 +586,65 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Evaluate the model by calculating the coherence score. \"Topic Coherence measures score a single topic by measuring the degree of semantic similarity between high scoring words in the topic.\"\n",
+    "\n",
+    "- Detailed introduction: https://towardsdatascience.com/evaluate-topic-model-in-python-latent-dirichlet-allocation-lda-7d57484bb5d0"
+   ]
+  },
+  {
    "cell_type": "code",
-   "execution_count": 148,
+   "execution_count": 19,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# evaluate the model by calculating the coherence score - we calculate c_v\n",
+    "from gensim.models.coherencemodel import CoherenceModel\n",
+    "cm = CoherenceModel(model=lda_model, texts=processed_docs, dictionary=dictionary, coherence='c_v')\n",
+    "coherence = cm.get_coherence()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Coherence score for our model is: 0.44\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(f\"Coherence score for our model is: {np.round(coherence, 2)}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
    "metadata": {
     "tags": []
    },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "Topic: 0 \nWords: 0.022*\"babylonian\" + 0.020*\"king\" + 0.017*\"string\" + 0.015*\"music\" + 0.013*\"languag\" + 0.013*\"sound\" + 0.012*\"nebuchadnezzar\" + 0.012*\"imag\" + 0.012*\"worship\" + 0.012*\"second\"\nTopic: 1 \nWords: 0.020*\"string\" + 0.019*\"note\" + 0.017*\"instrument\" + 0.015*\"like\" + 0.012*\"list\" + 0.011*\"music\" + 0.011*\"look\" + 0.010*\"liar\" + 0.010*\"play\" + 0.010*\"anchor\"\nTopic: 2 \nWords: 0.022*\"podcast\" + 0.017*\"music\" + 0.015*\"broadcast\" + 0.013*\"anchor\" + 0.011*\"note\" + 0.011*\"import\" + 0.010*\"cuneiform\" + 0.010*\"worship\" + 0.010*\"record\" + 0.009*\"time\"\nTopic: 3 \nWords: 0.026*\"music\" + 0.012*\"understand\" + 0.012*\"instrument\" + 0.012*\"number\" + 0.011*\"know\" + 0.011*\"imag\" + 0.010*\"chapter\" + 0.010*\"bibl\" + 0.010*\"king\" + 0.009*\"like\"\nTopic: 4 \nWords: 0.019*\"string\" + 0.018*\"instrument\" + 0.018*\"mode\" + 0.015*\"go\" + 0.014*\"copi\" + 0.010*\"fourth\" + 0.010*\"node\" + 0.009*\"tune\" + 0.009*\"like\" + 0.008*\"today\"\n"
+     "output_type": "stream",
+     "text": [
+      "Topic: 0 \n",
+      "Words: 0.022*\"babylonian\" + 0.020*\"king\" + 0.017*\"string\" + 0.015*\"music\" + 0.013*\"languag\" + 0.013*\"sound\" + 0.012*\"nebuchadnezzar\" + 0.012*\"imag\" + 0.012*\"worship\" + 0.012*\"second\"\n",
+      "Topic: 1 \n",
+      "Words: 0.020*\"string\" + 0.019*\"note\" + 0.017*\"instrument\" + 0.015*\"like\" + 0.012*\"list\" + 0.011*\"music\" + 0.011*\"look\" + 0.010*\"liar\" + 0.010*\"play\" + 0.010*\"anchor\"\n",
+      "Topic: 2 \n",
+      "Words: 0.022*\"podcast\" + 0.017*\"music\" + 0.015*\"broadcast\" + 0.013*\"anchor\" + 0.011*\"note\" + 0.011*\"import\" + 0.010*\"cuneiform\" + 0.010*\"worship\" + 0.010*\"record\" + 0.009*\"time\"\n",
+      "Topic: 3 \n",
+      "Words: 0.026*\"music\" + 0.012*\"understand\" + 0.012*\"instrument\" + 0.012*\"number\" + 0.011*\"know\" + 0.011*\"imag\" + 0.010*\"chapter\" + 0.010*\"bibl\" + 0.010*\"king\" + 0.009*\"like\"\n",
+      "Topic: 4 \n",
+      "Words: 0.019*\"string\" + 0.018*\"instrument\" + 0.018*\"mode\" + 0.015*\"go\" + 0.014*\"copi\" + 0.010*\"fourth\" + 0.010*\"node\" + 0.009*\"tune\" + 0.009*\"like\" + 0.008*\"today\"\n"
+     ]
     }
    ],
    "source": [
@@ -350,15 +668,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 149,
+   "execution_count": 22,
    "metadata": {
     "tags": []
    },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "CPU times: user 139 ms, sys: 31 ms, total: 170 ms\nWall time: 473 ms\n"
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 249 ms, sys: 55.2 ms, total: 304 ms\n",
+      "Wall time: 444 ms\n"
+     ]
     }
    ],
    "source": [
@@ -368,15 +689,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 150,
+   "execution_count": 23,
    "metadata": {
     "tags": []
    },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "Topic: 0 Word: 0.009*\"yeshua\" + 0.008*\"podcast\" + 0.008*\"anchor\" + 0.007*\"copi\" + 0.007*\"babylonian\" + 0.006*\"spirit\" + 0.006*\"tuna\" + 0.006*\"amen\" + 0.006*\"fourth\" + 0.006*\"shall\"\nTopic: 1 Word: 0.009*\"string\" + 0.008*\"imag\" + 0.008*\"final\" + 0.007*\"fall\" + 0.007*\"worship\" + 0.006*\"fifth\" + 0.006*\"liar\" + 0.006*\"kadosh\" + 0.006*\"music\" + 0.006*\"akaka\"\nTopic: 2 Word: 0.009*\"time\" + 0.008*\"understand\" + 0.007*\"opportun\" + 0.007*\"nation\" + 0.007*\"face\" + 0.007*\"gain\" + 0.006*\"broadcast\" + 0.006*\"donat\" + 0.006*\"radio\" + 0.006*\"scale\"\nTopic: 3 Word: 0.014*\"manuscript\" + 0.009*\"mode\" + 0.007*\"like\" + 0.007*\"matter\" + 0.007*\"generat\" + 0.006*\"joyous\" + 0.006*\"thing\" + 0.006*\"triton\" + 0.006*\"follow\" + 0.006*\"note\"\nTopic: 4 Word: 0.008*\"string\" + 0.007*\"strength\" + 0.007*\"nebuchadnezzar\" + 0.007*\"king\" + 0.007*\"look\" + 0.006*\"answer\" + 0.006*\"list\" + 0.006*\"beauti\" + 0.006*\"centuri\" + 0.006*\"think\"\n"
+     "output_type": "stream",
+     "text": [
+      "Topic: 0 Word: 0.009*\"yeshua\" + 0.008*\"podcast\" + 0.008*\"anchor\" + 0.007*\"copi\" + 0.007*\"babylonian\" + 0.006*\"spirit\" + 0.006*\"tuna\" + 0.006*\"amen\" + 0.006*\"fourth\" + 0.006*\"shall\"\n",
+      "Topic: 1 Word: 0.009*\"string\" + 0.008*\"imag\" + 0.008*\"final\" + 0.007*\"fall\" + 0.007*\"worship\" + 0.006*\"fifth\" + 0.006*\"liar\" + 0.006*\"kadosh\" + 0.006*\"music\" + 0.006*\"akaka\"\n",
+      "Topic: 2 Word: 0.009*\"time\" + 0.008*\"understand\" + 0.007*\"opportun\" + 0.007*\"nation\" + 0.007*\"face\" + 0.007*\"gain\" + 0.006*\"broadcast\" + 0.006*\"donat\" + 0.006*\"radio\" + 0.006*\"scale\"\n",
+      "Topic: 3 Word: 0.014*\"manuscript\" + 0.009*\"mode\" + 0.007*\"like\" + 0.007*\"matter\" + 0.007*\"generat\" + 0.006*\"joyous\" + 0.006*\"thing\" + 0.006*\"triton\" + 0.006*\"follow\" + 0.006*\"note\"\n",
+      "Topic: 4 Word: 0.008*\"string\" + 0.007*\"strength\" + 0.007*\"nebuchadnezzar\" + 0.007*\"king\" + 0.007*\"look\" + 0.006*\"answer\" + 0.006*\"list\" + 0.006*\"beauti\" + 0.006*\"centuri\" + 0.006*\"think\"\n"
+     ]
     }
    ],
    "source": [
@@ -400,16 +727,26 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 151,
+   "execution_count": 24,
    "metadata": {},
    "outputs": [
     {
-     "output_type": "execute_result",
      "data": {
-      "text/plain": "['inform',\n 'want',\n 'world',\n 'hear',\n 'want',\n 'outrag',\n 'fee',\n 'distributor',\n 'charg']"
+      "text/plain": [
+       "['inform',\n",
+       " 'want',\n",
+       " 'world',\n",
+       " 'hear',\n",
+       " 'want',\n",
+       " 'outrag',\n",
+       " 'fee',\n",
+       " 'distributor',\n",
+       " 'charg']"
+      ]
      },
+     "execution_count": 24,
      "metadata": {},
-     "execution_count": 151
+     "output_type": "execute_result"
     }
    ],
    "source": [
@@ -418,15 +755,31 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 152,
+   "execution_count": 25,
    "metadata": {
     "tags": []
    },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "\nScore: 0.9195331931114197\t \nTopic: 0.020*\"string\" + 0.019*\"note\" + 0.017*\"instrument\" + 0.015*\"like\" + 0.012*\"list\" + 0.011*\"music\" + 0.011*\"look\" + 0.010*\"liar\" + 0.010*\"play\" + 0.010*\"anchor\"\n\nScore: 0.02022414468228817\t \nTopic: 0.022*\"babylonian\" + 0.020*\"king\" + 0.017*\"string\" + 0.015*\"music\" + 0.013*\"languag\" + 0.013*\"sound\" + 0.012*\"nebuchadnezzar\" + 0.012*\"imag\" + 0.012*\"worship\" + 0.012*\"second\"\n\nScore: 0.02012956328690052\t \nTopic: 0.022*\"podcast\" + 0.017*\"music\" + 0.015*\"broadcast\" + 0.013*\"anchor\" + 0.011*\"note\" + 0.011*\"import\" + 0.010*\"cuneiform\" + 0.010*\"worship\" + 0.010*\"record\" + 0.009*\"time\"\n\nScore: 0.020068539306521416\t \nTopic: 0.019*\"string\" + 0.018*\"instrument\" + 0.018*\"mode\" + 0.015*\"go\" + 0.014*\"copi\" + 0.010*\"fourth\" + 0.010*\"node\" + 0.009*\"tune\" + 0.009*\"like\" + 0.008*\"today\"\n\nScore: 0.020044509321451187\t \nTopic: 0.026*\"music\" + 0.012*\"understand\" + 0.012*\"instrument\" + 0.012*\"number\" + 0.011*\"know\" + 0.011*\"imag\" + 0.010*\"chapter\" + 0.010*\"bibl\" + 0.010*\"king\" + 0.009*\"like\"\n"
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Score: 0.9195331931114197\t \n",
+      "Topic: 0.020*\"string\" + 0.019*\"note\" + 0.017*\"instrument\" + 0.015*\"like\" + 0.012*\"list\" + 0.011*\"music\" + 0.011*\"look\" + 0.010*\"liar\" + 0.010*\"play\" + 0.010*\"anchor\"\n",
+      "\n",
+      "Score: 0.02022414095699787\t \n",
+      "Topic: 0.022*\"babylonian\" + 0.020*\"king\" + 0.017*\"string\" + 0.015*\"music\" + 0.013*\"languag\" + 0.013*\"sound\" + 0.012*\"nebuchadnezzar\" + 0.012*\"imag\" + 0.012*\"worship\" + 0.012*\"second\"\n",
+      "\n",
+      "Score: 0.02012956142425537\t \n",
+      "Topic: 0.022*\"podcast\" + 0.017*\"music\" + 0.015*\"broadcast\" + 0.013*\"anchor\" + 0.011*\"note\" + 0.011*\"import\" + 0.010*\"cuneiform\" + 0.010*\"worship\" + 0.010*\"record\" + 0.009*\"time\"\n",
+      "\n",
+      "Score: 0.020068541169166565\t \n",
+      "Topic: 0.019*\"string\" + 0.018*\"instrument\" + 0.018*\"mode\" + 0.015*\"go\" + 0.014*\"copi\" + 0.010*\"fourth\" + 0.010*\"node\" + 0.009*\"tune\" + 0.009*\"like\" + 0.008*\"today\"\n",
+      "\n",
+      "Score: 0.020044507458806038\t \n",
+      "Topic: 0.026*\"music\" + 0.012*\"understand\" + 0.012*\"instrument\" + 0.012*\"number\" + 0.011*\"know\" + 0.011*\"imag\" + 0.010*\"chapter\" + 0.010*\"bibl\" + 0.010*\"king\" + 0.009*\"like\"\n"
+     ]
     }
    ],
    "source": [
@@ -450,15 +803,31 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 153,
+   "execution_count": 26,
    "metadata": {
     "tags": []
    },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "\nScore: 0.9195690155029297\t \nTopic: 0.009*\"string\" + 0.008*\"imag\" + 0.008*\"final\" + 0.007*\"fall\" + 0.007*\"worship\" + 0.006*\"fifth\" + 0.006*\"liar\" + 0.006*\"kadosh\" + 0.006*\"music\" + 0.006*\"akaka\"\n\nScore: 0.020143453031778336\t \nTopic: 0.009*\"time\" + 0.008*\"understand\" + 0.007*\"opportun\" + 0.007*\"nation\" + 0.007*\"face\" + 0.007*\"gain\" + 0.006*\"broadcast\" + 0.006*\"donat\" + 0.006*\"radio\" + 0.006*\"scale\"\n\nScore: 0.020101875066757202\t \nTopic: 0.008*\"string\" + 0.007*\"strength\" + 0.007*\"nebuchadnezzar\" + 0.007*\"king\" + 0.007*\"look\" + 0.006*\"answer\" + 0.006*\"list\" + 0.006*\"beauti\" + 0.006*\"centuri\" + 0.006*\"think\"\n\nScore: 0.0200973991304636\t \nTopic: 0.009*\"yeshua\" + 0.008*\"podcast\" + 0.008*\"anchor\" + 0.007*\"copi\" + 0.007*\"babylonian\" + 0.006*\"spirit\" + 0.006*\"tuna\" + 0.006*\"amen\" + 0.006*\"fourth\" + 0.006*\"shall\"\n\nScore: 0.020088206976652145\t \nTopic: 0.014*\"manuscript\" + 0.009*\"mode\" + 0.007*\"like\" + 0.007*\"matter\" + 0.007*\"generat\" + 0.006*\"joyous\" + 0.006*\"thing\" + 0.006*\"triton\" + 0.006*\"follow\" + 0.006*\"note\"\n"
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Score: 0.9195690155029297\t \n",
+      "Topic: 0.009*\"string\" + 0.008*\"imag\" + 0.008*\"final\" + 0.007*\"fall\" + 0.007*\"worship\" + 0.006*\"fifth\" + 0.006*\"liar\" + 0.006*\"kadosh\" + 0.006*\"music\" + 0.006*\"akaka\"\n",
+      "\n",
+      "Score: 0.020143458619713783\t \n",
+      "Topic: 0.009*\"time\" + 0.008*\"understand\" + 0.007*\"opportun\" + 0.007*\"nation\" + 0.007*\"face\" + 0.007*\"gain\" + 0.006*\"broadcast\" + 0.006*\"donat\" + 0.006*\"radio\" + 0.006*\"scale\"\n",
+      "\n",
+      "Score: 0.020101875066757202\t \n",
+      "Topic: 0.008*\"string\" + 0.007*\"strength\" + 0.007*\"nebuchadnezzar\" + 0.007*\"king\" + 0.007*\"look\" + 0.006*\"answer\" + 0.006*\"list\" + 0.006*\"beauti\" + 0.006*\"centuri\" + 0.006*\"think\"\n",
+      "\n",
+      "Score: 0.0200973991304636\t \n",
+      "Topic: 0.009*\"yeshua\" + 0.008*\"podcast\" + 0.008*\"anchor\" + 0.007*\"copi\" + 0.007*\"babylonian\" + 0.006*\"spirit\" + 0.006*\"tuna\" + 0.006*\"amen\" + 0.006*\"fourth\" + 0.006*\"shall\"\n",
+      "\n",
+      "Score: 0.020088206976652145\t \n",
+      "Topic: 0.014*\"manuscript\" + 0.009*\"mode\" + 0.007*\"like\" + 0.007*\"matter\" + 0.007*\"generat\" + 0.006*\"joyous\" + 0.006*\"thing\" + 0.006*\"triton\" + 0.006*\"follow\" + 0.006*\"note\"\n"
+     ]
     }
    ],
    "source": [
@@ -482,15 +851,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 154,
+   "execution_count": 27,
    "metadata": {
     "tags": []
    },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "Score: 0.4102005958557129\t Topic: 0.022*\"podcast\" + 0.017*\"music\" + 0.015*\"broadcast\" + 0.013*\"anchor\" + 0.011*\"note\"\nScore: 0.38971903920173645\t Topic: 0.020*\"string\" + 0.019*\"note\" + 0.017*\"instrument\" + 0.015*\"like\" + 0.012*\"list\"\nScore: 0.06670007854700089\t Topic: 0.019*\"string\" + 0.018*\"instrument\" + 0.018*\"mode\" + 0.015*\"go\" + 0.014*\"copi\"\nScore: 0.0666906014084816\t Topic: 0.026*\"music\" + 0.012*\"understand\" + 0.012*\"instrument\" + 0.012*\"number\" + 0.011*\"know\"\nScore: 0.06668967008590698\t Topic: 0.022*\"babylonian\" + 0.020*\"king\" + 0.017*\"string\" + 0.015*\"music\" + 0.013*\"languag\"\n"
+     "output_type": "stream",
+     "text": [
+      "Score: 0.4102005362510681\t Topic: 0.022*\"podcast\" + 0.017*\"music\" + 0.015*\"broadcast\" + 0.013*\"anchor\" + 0.011*\"note\"\n",
+      "Score: 0.3897190988063812\t Topic: 0.020*\"string\" + 0.019*\"note\" + 0.017*\"instrument\" + 0.015*\"like\" + 0.012*\"list\"\n",
+      "Score: 0.06670007854700089\t Topic: 0.019*\"string\" + 0.018*\"instrument\" + 0.018*\"mode\" + 0.015*\"go\" + 0.014*\"copi\"\n",
+      "Score: 0.0666906014084816\t Topic: 0.026*\"music\" + 0.012*\"understand\" + 0.012*\"instrument\" + 0.012*\"number\" + 0.011*\"know\"\n",
+      "Score: 0.06668966263532639\t Topic: 0.022*\"babylonian\" + 0.020*\"king\" + 0.017*\"string\" + 0.015*\"music\" + 0.013*\"languag\"\n"
+     ]
     }
    ],
    "source": [
@@ -504,9 +879,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3.7.6 64-bit ('venv': venv)",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "python_defaultSpec_1598387632287"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -518,7 +893,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.6-final"
+   "version": "3.7.7"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
For LDA models, this commit contains the calculation for coherence score. It influences two Jupiter notebook files: "LDA_news_headlines.ipynb" and "LDA_podcast.ipynb".